### PR TITLE
Bring Policy Attributes Through Exposure Calculation

### DIFF
--- a/R/exposure_functions.R
+++ b/R/exposure_functions.R
@@ -37,8 +37,20 @@ makeRange <- function(duration){
 #' @examples
 #' addExposures(records)
 #' @export
-addExposures <- function(records, type = "PY", lower_year = NULL, upper_year = NULL,
-                         keep_extra_cols = TRUE){
+addExposures <- function(records, start_var = start, end_var = end,
+                         key_var = key, type = "PY", lower_year = NULL,
+                         upper_year = NULL, keep_extra_cols = TRUE) {
+  start_var = enquo(start_var)
+  end_var = enquo(end_var)
+  key_var = enquo(key_var)
+
+  # Rename user supplied names to start/end
+  # See ?rlang::`!!` for documentation on tidy evaluation
+  records <- records %>%
+    dplyr::mutate(start = !!start_var,
+                  end = !!end_var,
+                  key = !!key_var)
+
   #Require a unique key.
   if(anyDuplicated(records$key)){
     stop('Key is not unique')
@@ -203,6 +215,11 @@ addExposures <- function(records, type = "PY", lower_year = NULL, upper_year = N
     result <- result %>%
       dplyr::left_join(extra_vars, by = "key")
   }
+
+  # Rename key to original name
+  #result <- result %>%
+  #  mutate(sym(key_var) = key) %>%
+  #  select(-key)
 
   result
 }

--- a/R/exposure_functions.R
+++ b/R/exposure_functions.R
@@ -37,7 +37,8 @@ makeRange <- function(duration){
 #' @examples
 #' addExposures(records)
 #' @export
-addExposures <- function(records, type = "PY", lower_year = NULL, upper_year = NULL){
+addExposures <- function(records, type = "PY", lower_year = NULL, upper_year = NULL,
+                         keep_extra_cols = TRUE){
   #Require a unique key.
   if(anyDuplicated(records$key)){
     stop('Key is not unique')
@@ -50,8 +51,10 @@ addExposures <- function(records, type = "PY", lower_year = NULL, upper_year = N
 
   # Pull out variables not needed for exposure calculations and store in order
   # to reattach them later via the unique key
-  extra_vars <- records %>%
-    dplyr::select(-c(start, end))
+  if(keep_extra_cols) {
+    extra_vars <- records %>%
+      dplyr::select(-c(start, end))
+  }
 
   #Increment up the start interval to the year prior lower_year to reduce calculation size.
   #Filtered later for an exact lower truncation. key_and_year increment is book-keeping
@@ -196,8 +199,10 @@ addExposures <- function(records, type = "PY", lower_year = NULL, upper_year = N
   }
 
   # Add on the extra variables we are carrying through the exposure calculation
-  result <- result %>%
-    dplyr::left_join(extra_vars, by = "key")
+  if(keep_extra_cols) {
+    result <- result %>%
+      dplyr::left_join(extra_vars, by = "key")
+  }
 
   result
 }

--- a/R/exposure_functions.R
+++ b/R/exposure_functions.R
@@ -48,6 +48,11 @@ addExposures <- function(records, type = "PY", lower_year = NULL, upper_year = N
     stop('invalid type argument')
   }
 
+  # Pull out variables not needed for exposure calculations and store in order
+  # to reattach them later via the unique key
+  extra_vars <- records %>%
+    dplyr::select(-c(start, end))
+
   #Increment up the start interval to the year prior lower_year to reduce calculation size.
   #Filtered later for an exact lower truncation. key_and_year increment is book-keeping
   if(!is.null(lower_year)){
@@ -189,6 +194,10 @@ addExposures <- function(records, type = "PY", lower_year = NULL, upper_year = N
       dplyr::select(-year_increment) %>%
       dplyr::filter(lubridate::year(start_int) >= lower_year)
   }
+
+  # Add on the extra variables we are carrying through the exposure calculation
+  result <- result %>%
+    dplyr::left_join(extra_vars, by = "key")
 
   result
 }

--- a/tests/testthat/test-exposure_functions.R
+++ b/tests/testthat/test-exposure_functions.R
@@ -61,3 +61,13 @@ test_that("lower_year argument works for truncation", {
   expect_equal(all.equal(addExposures(old_record_start, type = "PYCM", lower_year = 2000), good_old_PYCM), TRUE)
   expect_equal(all.equal(addExposures(old_record_start, type = "PMCY", lower_year = 2000), good_old_PMCY), TRUE)
   expect_equal(all.equal(addExposures(old_record_start, type = "PMCM", lower_year = 2000), good_old_PMCM), TRUE)})
+
+test_that("Pulling variables through addExposures works", {
+  expect_equal(addExposures(records)$gender[1:9], rep("M", 9))
+  expect_equal(addExposures(records)$gender[10:18], rep("F", 9))
+  expect_equal(addExposures(records)$issue_age[1:9], rep(35, 9))
+  expect_equal(addExposures(records)$issue_age[10:18], rep(30, 9))
+  expect_equal("gender" %in%    colnames(addExposures(records, keep_extra_cols = FALSE)), FALSE)
+  expect_equal("issue_age" %in% colnames(addExposures(records, keep_extra_cols = FALSE)), FALSE)
+})
+


### PR DESCRIPTION
This code adds functionality to pull policy attributes in the form of variables in the input dataset through the addExposures function.  This can be turned off with a parameter in the addExposures call.  This will change the default behavior of addExposures so any existing user code that needs to stay exactly the same will need to be changed.   Also includes tests using expstudies::records to ensure functionality is working correctly.